### PR TITLE
Don't return when not reading any input events

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -163,15 +163,11 @@ impl Console {
         Ok(utf8.as_bytes().len())
     }
 
-    pub fn read_single_input_event(&self) -> Result<Option<InputRecord>> {
-        let buf_len = self.number_of_console_input_events()?;
-
+    pub fn read_single_input_event(&self) -> Result<InputRecord> {
         let mut buf: Vec<INPUT_RECORD> = Vec::with_capacity(1);
         let mut size = 0;
 
-
-        /// TODO: remove Option from function.
-        return Ok(Some(self.read_input(&mut buf, 1, &mut size)?.1[0].to_owned()));
+        return Ok(self.read_input(&mut buf, 1, &mut size)?.1[0].to_owned());
     }
 
     pub fn read_console_input(&self) -> Result<(u32, Vec<InputRecord>)> {

--- a/src/console.rs
+++ b/src/console.rs
@@ -164,20 +164,14 @@ impl Console {
     }
 
     pub fn read_single_input_event(&self) -> Result<Option<InputRecord>> {
-        // loop until we have events, TODO: replace with async
-        loop {
-            let buf_len = self.number_of_console_input_events()?;
+        let buf_len = self.number_of_console_input_events()?;
 
-            // Fast-skipping all the code below if there is nothing to read at all
-            if buf_len == 0 {
-                continue;
-            }
+        let mut buf: Vec<INPUT_RECORD> = Vec::with_capacity(1);
+        let mut size = 0;
 
-            let mut buf: Vec<INPUT_RECORD> = Vec::with_capacity(1);
-            let mut size = 0;
 
-            return Ok(Some(self.read_input(&mut buf, 1, &mut size)?.1[0].to_owned()));
-        }
+        /// TODO: remove Option from function.
+        return Ok(Some(self.read_input(&mut buf, 1, &mut size)?.1[0].to_owned()));
     }
 
     pub fn read_console_input(&self) -> Result<(u32, Vec<InputRecord>)> {

--- a/src/console.rs
+++ b/src/console.rs
@@ -164,20 +164,20 @@ impl Console {
     }
 
     pub fn read_single_input_event(&self) -> Result<Option<InputRecord>> {
-        let buf_len = self.number_of_console_input_events()?;
+        // loop until we have events, TODO: replace with async
+        loop {
+            let buf_len = self.number_of_console_input_events()?;
 
-        // Fast-skipping all the code below if there is nothing to read at all
-        if buf_len == 0 {
-            return Ok(None);
+            // Fast-skipping all the code below if there is nothing to read at all
+            if buf_len == 0 {
+                continue;
+            }
+
+            let mut buf: Vec<INPUT_RECORD> = Vec::with_capacity(1);
+            let mut size = 0;
+
+            return Ok(Some(self.read_input(&mut buf, 1, &mut size)?.1[0].to_owned()));
         }
-
-        let mut buf: Vec<INPUT_RECORD> = Vec::with_capacity(1);
-        let mut size = 0;
-
-        let a = self.read_input(&mut buf, 1, &mut size)?.1[0].to_owned();
-
-        // read single input event
-        Ok(Some(a))
     }
 
     pub fn read_console_input(&self) -> Result<(u32, Vec<InputRecord>)> {


### PR DESCRIPTION
Attempt to fix https://github.com/crossterm-rs/crossterm/issues/195

So this is an 'attempt' to fix this issue, altough I am not sure we should do something like this. I have checked the [.Net framework source code](https://referencesource.microsoft.com/#mscorlib/system/console.cs,1496) out and they seem to do this the same way. This could be a temporary fix until we are going to refactor the input crate.

