### PR TITLE
fix repository link in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "crossterm_winapi"
 version = "0.3.0"
 authors = ["T. Post"]
-description = "An WinApi wrapper that provides some basic simple abstractions aground common WinApi calls"
-repository = "https://github.com/crossterm-rs/crossterm"
+description = "WinAPI wrapper that provides some basic simple abstractions around common WinAPI calls"
+repository = "https://github.com/crossterm-rs/crossterm-winapi"
 documentation = "https://docs.rs/crossterm_winapi/"
 license = "MIT"
 keywords = ["winapi", "abstractions", "crossterm", "windows", "screen_buffer"]


### PR DESCRIPTION
Fix repository link which was linking to `crossterm` instead linking to `crossterm-winapi` repository as well as fix some typos in description of crate