### PR TITLE
Make Handle close on drop and Send + Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Version 0.4.0
+- The `Handle` API has been reworked to make it `Send` + `Sync` and close the underlying `HANDLE` when dropped ([PR #7](https://github.com/crossterm-rs/crossterm-winapi/pull/7)).
+
 # Version 0.3.0
 
 - Make read sync block for windows systems ([PR #2](https://github.com/crossterm-rs/crossterm-winapi/pull/2))

--- a/examples/coloring_example.rs
+++ b/examples/coloring_example.rs
@@ -21,7 +21,7 @@ fn set_background_color() -> Result<()> {
     let new_color = fg_color | BLUE_BACKGROUND;
 
     // set the console text attribute to the new color value.
-    Console::from(**screen_buffer.handle()).set_text_attribute(new_color)?;
+    Console::from(screen_buffer.handle().clone()).set_text_attribute(new_color)?;
 
     Ok(())
 }
@@ -47,7 +47,7 @@ fn set_foreground_color() -> Result<()> {
     }
 
     // set the console text attribute to the new color value.
-    Console::from(**screen_buffer.handle()).set_text_attribute(color)?;
+    Console::from(screen_buffer.handle().clone()).set_text_attribute(color)?;
 
     Ok(())
 }

--- a/examples/handle.rs
+++ b/examples/handle.rs
@@ -19,7 +19,7 @@ fn main() -> Result<()> {
     let handle /*:HANDLE*/ = *out_put_handle;
 
     // you can also pass you own `HANDLE` to create an instance of `Handle`
-    let handle = Handle::from(handle); /* winapi::um::winnt::HANDLE */
+    let handle = unsafe { Handle::from_raw(handle) }; /* winapi::um::winnt::HANDLE */
 
     Ok(())
 }

--- a/src/console.rs
+++ b/src/console.rs
@@ -6,12 +6,9 @@ use winapi::ctypes::c_void;
 use winapi::shared::minwindef::DWORD;
 use winapi::shared::ntdef::NULL;
 use winapi::um::consoleapi::{GetNumberOfConsoleInputEvents, ReadConsoleInputW, WriteConsoleW};
-use winapi::um::{
-    wincon::{
-        FillConsoleOutputAttribute, FillConsoleOutputCharacterA, GetLargestConsoleWindowSize,
-        SetConsoleTextAttribute, SetConsoleWindowInfo, COORD, INPUT_RECORD, SMALL_RECT,
-    },
-    winnt::HANDLE,
+use winapi::um::wincon::{
+    FillConsoleOutputAttribute, FillConsoleOutputCharacterA, GetLargestConsoleWindowSize,
+    SetConsoleTextAttribute, SetConsoleWindowInfo, COORD, INPUT_RECORD, SMALL_RECT,
 };
 
 use super::{is_true, Coord, Handle, HandleType, InputRecord, WindowPositions};
@@ -25,7 +22,7 @@ impl Console {
     /// Create new instance of `Console`.
     ///
     /// This created instance will use the default output handle (STD_OUTPUT_HANDLE) as handle for the function call it wraps.
-    pub fn new() -> Result<Console> {
+    pub fn output() -> Result<Console> {
         Ok(Console {
             handle: Handle::new(HandleType::OutputHandle)?,
         })
@@ -223,14 +220,5 @@ impl From<Handle> for Console {
     /// Create a `Console` instance who's functions will be executed on the the given `Handle`
     fn from(handle: Handle) -> Self {
         Console { handle }
-    }
-}
-
-impl From<HANDLE> for Console {
-    /// Create a `Console` instance who's functions will be executed on the the given `HANDLE`
-    fn from(handle: HANDLE) -> Self {
-        Console {
-            handle: Handle::from(handle),
-        }
     }
 }

--- a/src/console_mode.rs
+++ b/src/console_mode.rs
@@ -1,7 +1,6 @@
 use std::io::{Error, Result};
 
 use winapi::um::consoleapi::{GetConsoleMode, SetConsoleMode};
-use winapi::um::winnt::HANDLE;
 
 use super::{is_true, Handle, HandleType};
 
@@ -58,14 +57,6 @@ impl ConsoleMode {
             }
         }
         Ok(console_mode)
-    }
-}
-
-impl From<HANDLE> for ConsoleMode {
-    fn from(handle: HANDLE) -> Self {
-        ConsoleMode {
-            handle: Handle::from(handle),
-        }
     }
 }
 

--- a/src/screen_buffer.rs
+++ b/src/screen_buffer.rs
@@ -12,17 +12,22 @@ use winapi::{
             CreateConsoleScreenBuffer, GetConsoleScreenBufferInfo, SetConsoleActiveScreenBuffer,
             SetConsoleScreenBufferSize, CONSOLE_TEXTMODE_BUFFER, COORD,
         },
-        winnt::{FILE_SHARE_READ, FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE, HANDLE},
+        winnt::{FILE_SHARE_READ, FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE},
     },
 };
 
 use super::{is_true, Handle, HandleType, ScreenBufferInfo};
 
+#[derive(Clone)]
 pub struct ScreenBuffer {
     handle: Handle,
 }
 
 impl ScreenBuffer {
+    pub fn new(handle: Handle) -> Self {
+        Self { handle }
+    }
+
     /// Create an instance of `ScreenBuffer` where the `HANDLE`, used for the functions this type wraps, is the current output handle.
     pub fn current() -> Result<ScreenBuffer> {
         Ok(ScreenBuffer {
@@ -51,7 +56,7 @@ impl ScreenBuffer {
                 NULL,
             );
             ScreenBuffer {
-                handle: Handle::from(new_screen_buffer),
+                handle: Handle::from_raw(new_screen_buffer),
             }
         }
     }
@@ -110,14 +115,6 @@ impl ScreenBuffer {
 impl From<Handle> for ScreenBuffer {
     fn from(handle: Handle) -> Self {
         ScreenBuffer { handle }
-    }
-}
-
-impl From<HANDLE> for ScreenBuffer {
-    fn from(handle: HANDLE) -> Self {
-        ScreenBuffer {
-            handle: Handle::from(handle),
-        }
     }
 }
 


### PR DESCRIPTION
You now must construct a handle by calling the unsafe function `Handle::from_raw`, which requires that you guarantee that the underlying HANDLE is thread safe.

It's worth noting that most handles in winapi are thread safe.

`Handle`s also need to be shared currently, so we wrap the inner handle in an Arc.

We also remove all conversion APIs which allows constructing a `Handle` from a raw `HANDLE`, since this could be used to circumvent the guarantees provided by `Send` and `Sync` without using `unsafe`.

This also adds bookkeeping for closing handles. Since we didn't do this before, we were leaking them instead on every operation.