### PR TITLE
Reimplemented `read_single_input_event` and `read_console_input`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 edition = "2018"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version =  "0.3.8", features = ["winbase", "consoleapi", "processenv", "handleapi", "synchapi"] }
+winapi = { version =  "0.3.8", features = ["winbase", "consoleapi", "processenv", "handleapi", "synchapi", "impl-default"] }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/src/console.rs
+++ b/src/console.rs
@@ -203,20 +203,27 @@ impl Console {
         if is_true(unsafe { GetNumberOfConsoleInputEvents(*self.handle, &mut buf_len) }) {
             Ok(buf_len)
         } else {
-            Err(Error::last_os_error());
+            Err(Error::last_os_error())
         }
     }
 
     /// Read input (via ReadConsoleInputW) into buf and return the number
     /// of events read. ReadConsoleInputW guarantees that at least one event
-    /// is read, even if it means blocking the thread.
+    /// is read, even if it means blocking the thread. buf.len() must fit in
+    /// a u32.
     fn read_input(&self, buf: &mut [INPUT_RECORD]) -> Result<usize> {
         let mut num_records = 0;
+        debug_assert!(buf.len() < std::u32::MAX as usize);
 
         if !is_true(unsafe {
-            ReadConsoleInputW(*self.handle, buf.as_mut_ptr(), buf.len(), &mut num_records)
+            ReadConsoleInputW(
+                *self.handle,
+                buf.as_mut_ptr(),
+                buf.len() as u32,
+                &mut num_records,
+            )
         }) {
-            Err(Error::last_os_error());
+            Err(Error::last_os_error())
         } else {
             Ok(num_records as usize)
         }

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,5 +1,5 @@
-use std::borrow::ToOwned;
 use std::io::{self, Error, Result};
+use std::iter;
 use std::slice;
 use std::str;
 


### PR DESCRIPTION
- Correctness changes: no longer ignores the `NumberOfEventsRead` output parameter. The existing code tried to always use `GetNumberOfConsoleInputEvents` to ensure that this doesn't matter, but there's no reason to do it incorrectly in the first place.
- Safety changes: no longer uses `set_len` (the existing implementation was technically unsound, see above)
- Efficiency changes: `read_input` and `read_single_input_event` no longer allocate
- Usability changes: functions take and return fewer redundant parameters.
  - read_input has a much simpler signature
  - read_console_input no longer returns a redundant u32