### PR TITLE
Do not output to stdout when certain steps fail

### DIFF
--- a/src/console_mode.rs
+++ b/src/console_mode.rs
@@ -53,7 +53,6 @@ impl ConsoleMode {
         let mut console_mode = 0;
         unsafe {
             if !is_true(GetConsoleMode(*self.handle, &mut console_mode)) {
-                println!("Getting mode failed");
                 return Err(Error::last_os_error());
             }
         }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -130,7 +130,6 @@ impl Handle {
         };
 
         if !Self::is_valid_handle(&handle) {
-            println!("invalid!!");
             return Err(io::Error::last_os_error());
         }
 


### PR DESCRIPTION
If anything these probably should have been `eprintln`, but I think it's better just to remove them as there will be other obvious indications something's not working.