### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ API could be expected.
 
 This crate provides some abstractions over reading input, console screen buffer, and handle.
 
-The following WinApi calls:
+The following WinAPI calls:
 
 - CONSOLE_SCREEN_BUFFER_INFO (used to extract information like cursor pos, terminal size etc.)
-- HANDLE (the handle needed to run functions from WinApi)
+- HANDLE (the handle needed to run functions from WinAPI)
 - SetConsoleActiveScreenBuffer (activate an other screen buffer)
 - Set/GetConsoleMode (e.g. console modes like disabling output)
 - SetConsoleTextAttribute (eg. coloring)

--- a/docs/known-problems.md
+++ b/docs/known-problems.md
@@ -1,10 +1,10 @@
 # Known problems
 
 There are some problems I discovered during development. I don't think it has to do anything with
-the crossterm, but it has to do whit how terminals handle ANSI or WinAPI. 
+the crossterm, but it has to do with how terminals handle ANSI or WinAPI. 
 
 ## WinAPI
 
-- Power shell does not interpreter 'DarkYellow' and is instead using gray instead, cmd is working perfectly fine.
-- Power shell inserts an '\n' (enter) when the program starts, this enter is the one you pressed when running the command.
-- After the program ran, power shell will reset the background and foreground colors.
+- PowerShell does not interpret 'DarkYellow' and uses gray instead, cmd is working perfectly fine.
+- PowerShell inserts an '\n' (enter) when the program starts, this enter is the one you pressed when running the command.
+- After the program ran, PowerShell will reset the background and foreground colors.

--- a/examples/handle.rs
+++ b/examples/handle.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
     let curr_out_put_handle = Handle::new(HandleType::CurrentOutputHandle)?;
     let curr_out_put_handle = Handle::new(HandleType::CurrentInputHandle)?;
 
-    // now you have this handle you might want to get the WinApi `HANDLE` it is wrapping.
+    // now you have this handle you might want to get the WinAPI `HANDLE` it is wrapping.
     // you can do this by defencing.
 
     let handle /*:HANDLE*/ = *out_put_handle;

--- a/src/console_mode.rs
+++ b/src/console_mode.rs
@@ -4,13 +4,10 @@ use winapi::um::consoleapi::{GetConsoleMode, SetConsoleMode};
 
 use super::{is_true, Handle, HandleType};
 
-/// This abstracts away some WinaApi calls to set and get the console mode.
+/// A wrapper around a screen buffer, focusing on calls to get and set the console mode.
 ///
-/// Wraps the underlying function call: [SetConsoleMode]
-/// link: [https://docs.microsoft.com/en-us/windows/console/setconsolemode]
-///
-/// Wraps the underlying function call: [GetConsoleMode]
-/// link: [https://docs.microsoft.com/en-us/windows/console/getconsolemode]
+/// This wraps [`SetConsoleMode`](https://docs.microsoft.com/en-us/windows/console/setconsolemode)
+/// and [`GetConsoleMode`](https://docs.microsoft.com/en-us/windows/console/getconsolemode).
 #[derive(Debug, Clone)]
 pub struct ConsoleMode {
     // the handle used for the functions of this type.
@@ -20,7 +17,7 @@ pub struct ConsoleMode {
 impl ConsoleMode {
     /// Create a new `ConsoleMode` instance.
     ///
-    /// This will use the `STD_OUTPUT_HANDLE` as default handle.
+    /// This will use the standard output as its handle.
     /// When you explicitly want to specify the handle used for the function calls use `ConsoleMode::from(handle)` instead.
     pub fn new() -> Result<ConsoleMode> {
         Ok(ConsoleMode {
@@ -32,8 +29,8 @@ impl ConsoleMode {
     ///
     /// This function sets the `dwMode`.
     ///
-    /// Wraps the underlying function call: [SetConsoleMode]
-    /// link: [https://docs.microsoft.com/en-us/windows/console/setconsolemode]
+    /// This wraps
+    /// [`SetConsoleMode`](https://docs.microsoft.com/en-us/windows/console/setconsolemode).
     pub fn set_mode(&self, console_mode: u32) -> Result<()> {
         unsafe {
             if !is_true(SetConsoleMode(*self.handle, console_mode)) {
@@ -47,8 +44,8 @@ impl ConsoleMode {
     ///
     /// This function returns the `lpMode`.
     ///
-    /// Wraps the underlying function call: [GetConsoleMode]
-    /// link: [https://docs.microsoft.com/en-us/windows/console/getconsolemode]
+    /// This wraps
+    /// [`GetConsoleMode`](https://docs.microsoft.com/en-us/windows/console/getconsolemode).
     pub fn mode(&self) -> Result<u32> {
         let mut console_mode = 0;
         unsafe {

--- a/src/csbi.rs
+++ b/src/csbi.rs
@@ -5,10 +5,10 @@ use winapi::um::wincon::CONSOLE_SCREEN_BUFFER_INFO;
 
 use super::{Coord, Size, WindowPositions};
 
-/// This type is a wrapper for `CONSOLE_SCREEN_BUFFER_INFO` and has some methods to extract information from it.
+/// Information about a console screen buffer.
 ///
-/// Wraps the underlying type: [CONSOLE_SCREEN_BUFFER_INFO]
-/// link: [https://docs.microsoft.com/en-us/windows/console/console-screen-buffer-info-str]
+/// This wraps
+/// [`CONSOLE_SCREEN_BUFFER_INFO`](https://docs.microsoft.com/en-us/windows/console/console-screen-buffer-info-str).
 // TODO: replace the innards of this type with our own, more friendly types, like Coord.
 // This will obviously be a breaking change.
 #[derive(Clone)]
@@ -31,20 +31,21 @@ impl fmt::Debug for ScreenBufferInfo {
 }
 
 impl ScreenBufferInfo {
+    /// Create a new console screen buffer without all zeroed properties.
     pub fn new() -> ScreenBufferInfo {
         ScreenBufferInfo(unsafe { zeroed() })
     }
 
-    /// This will return the buffer size.
+    /// Get the size of the screen buffer.
     ///
-    /// Will take `dwSize` from the current screen buffer and convert it into the `Size`.
+    /// Will take `dwSize` from the current screen buffer and convert it into a [`Size`].
     pub fn buffer_size(&self) -> Size {
         Size::from(self.0.dwSize)
     }
 
-    /// This will return the terminal size.
+    /// Get the size of the terminal display window.
     ///
-    /// Will calculate the width and height from `srWindow` and convert it into a `Size`.
+    /// Will calculate the width and height from `srWindow` and convert it into a [`Size`].
     pub fn terminal_size(&self) -> Size {
         (Size::new(
             self.0.srWindow.Right - self.0.srWindow.Left,
@@ -52,21 +53,21 @@ impl ScreenBufferInfo {
         ))
     }
 
-    /// This will return the terminal window properties.
+    /// Get the position and size of the terminal display window.
     ///
     /// Will take `srWindow` and convert it into the `WindowPositions` type.
     pub fn terminal_window(&self) -> WindowPositions {
         WindowPositions::from(self.0)
     }
 
-    /// This will return the terminal window properties.
+    /// Get the current attributes of the characters that are being written to the console.
     ///
     /// Will take `wAttributes` from the current screen buffer.
     pub fn attributes(&self) -> u16 {
         self.0.wAttributes
     }
 
-    /// This will return the current cursor position.
+    /// Get the current column and row of the terminal cursor in the screen buffer.
     ///
     /// Will take `dwCursorPosition` from the current screen buffer.
     pub fn cursor_pos(&self) -> Coord {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ mod semaphore;
 mod structs;
 
 /// Parses the given integer to an bool by checking if the value is 0 or 1.
-/// This is currently used for checking if a WinApi called succeeded, this might be moved into a macro at some time.
+/// This is currently used for checking if a WinAPI called succeeded, this might be moved into a macro at some time.
 /// So please don't use this :(.
 #[inline(always)]
 pub fn is_true(value: i32) -> bool {

--- a/src/screen_buffer.rs
+++ b/src/screen_buffer.rs
@@ -18,17 +18,19 @@ use winapi::{
 
 use super::{is_true, Handle, HandleType, ScreenBufferInfo};
 
+/// A wrapper around a screen buffer.
 #[derive(Clone, Debug)]
 pub struct ScreenBuffer {
     handle: Handle,
 }
 
 impl ScreenBuffer {
+    /// Create a wrapper around a screen buffer from its handle.
     pub fn new(handle: Handle) -> Self {
         Self { handle }
     }
 
-    /// Create an instance of `ScreenBuffer` where the `HANDLE`, used for the functions this type wraps, is the current output handle.
+    /// Get the current console screen buffer
     pub fn current() -> Result<ScreenBuffer> {
         Ok(ScreenBuffer {
             handle: Handle::new(HandleType::CurrentOutputHandle)?,
@@ -37,8 +39,8 @@ impl ScreenBuffer {
 
     /// Create new console screen buffer.
     ///
-    /// Wraps the underlying function call: [CreateConsoleScreenBuffer]
-    /// link: [https://docs.microsoft.com/en-us/windows/console/createconsolescreenbuffer]
+    /// This wraps
+    /// [`CreateConsoleScreenBuffer`](https://docs.microsoft.com/en-us/windows/console/createconsolescreenbuffer)
     pub fn create() -> ScreenBuffer {
         let mut security_attr: SECURITY_ATTRIBUTES = SECURITY_ATTRIBUTES {
             nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
@@ -61,10 +63,10 @@ impl ScreenBuffer {
         }
     }
 
-    /// This will make this `ScreenBuffer` the active one.
+    /// Set this screen buffer to the current one.
     ///
-    /// Wraps the underlying function call: [SetConsoleActiveScreenBuffer]
-    /// link: [https://docs.microsoft.com/en-us/windows/console/setconsoleactivescreenbuffer]
+    /// This wraps
+    /// [`SetConsoleActiveScreenBuffer`](https://docs.microsoft.com/en-us/windows/console/setconsoleactivescreenbuffer).
     pub fn show(&self) -> Result<()> {
         unsafe {
             if !is_true(SetConsoleActiveScreenBuffer(*self.handle)) {
@@ -76,8 +78,8 @@ impl ScreenBuffer {
 
     /// Get the screen buffer information like terminal size, cursor position, buffer size.
     ///
-    /// Wraps the underlying function call: [GetConsoleScreenBufferInfo]
-    /// link: [https://docs.microsoft.com/en-us/windows/console/getconsolescreenbufferinfo]
+    /// This wraps
+    /// [`GetConsoleScreenBufferInfo`](https://docs.microsoft.com/en-us/windows/console/getconsolescreenbufferinfo).
     pub fn info(&self) -> Result<ScreenBufferInfo> {
         let mut csbi = ScreenBufferInfo::new();
 
@@ -92,8 +94,8 @@ impl ScreenBuffer {
 
     /// Set the console screen buffer size to the given size.
     ///
-    /// Wraps the underlying function call: [SetConsoleScreenBufferSize]
-    /// link: [https://docs.microsoft.com/en-us/windows/console/setconsolescreenbuffersize]
+    /// This wraps
+    /// [`SetConsoleScreenBufferSize`](https://docs.microsoft.com/en-us/windows/console/setconsolescreenbuffersize).
     pub fn set_size(&self, x: i16, y: i16) -> Result<()> {
         unsafe {
             if !is_true(SetConsoleScreenBufferSize(
@@ -106,7 +108,7 @@ impl ScreenBuffer {
         Ok(())
     }
 
-    /// Get the underlining raw `HANDLE` used by this type to execute whit.
+    /// Get the underlying raw `HANDLE` used by this type to execute with.
     pub fn handle(&self) -> &Handle {
         return &self.handle;
     }

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -2,11 +2,15 @@ use crate::Handle;
 use std::{io, ptr};
 use winapi::um::synchapi::{CreateSemaphoreW, ReleaseSemaphore};
 
+/// A [Windows semaphore](https://docs.microsoft.com/en-us/windows/win32/sync/semaphore-objects).
 #[derive(Clone, Debug)]
 pub struct Semaphore(Handle);
 
 impl Semaphore {
     /// Construct a new semaphore.
+    ///
+    /// This wraps
+    /// [`CreateSemaphoreW`](https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createsemaphorew).
     pub fn new() -> io::Result<Self> {
         let handle = unsafe { CreateSemaphoreW(ptr::null_mut(), 0, 1, ptr::null_mut()) };
 
@@ -19,6 +23,9 @@ impl Semaphore {
     }
 
     /// Release a permit on the semaphore.
+    ///
+    /// This wraps
+    /// [`ReleaseSemaphore`](https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-releasesemaphore).
     pub fn release(&self) -> io::Result<()> {
         let result = unsafe { ReleaseSemaphore(*self.0, 1, ptr::null_mut()) };
 

--- a/src/structs/coord.rs
+++ b/src/structs/coord.rs
@@ -1,6 +1,6 @@
 //! This module provides a type that represents some location/coordination.
-//! For example, in WinAPi we have `COORD` which looks and feels inconvenient.
-//! This module provides also some trait implementations who will make parsing and working whit `COORD` easier.
+//! For example, in WinAPI we have `COORD` which looks and feels inconvenient.
+//! This module provides also some trait implementations who will make parsing and working with `COORD` easier.
 
 use winapi::um::wincon::COORD;
 
@@ -14,7 +14,7 @@ pub struct Coord {
 }
 
 impl Coord {
-    /// Create a new size instance by passing in the width and height.
+    /// Create a new coordinate from its x and y position.
     pub fn new(x: i16, y: i16) -> Coord {
         Coord { x, y }
     }

--- a/src/structs/input.rs
+++ b/src/structs/input.rs
@@ -130,7 +130,7 @@ impl From<DWORD> for ButtonState {
 }
 
 impl ButtonState {
-    /// Whether no buttons are being pressed.
+    /// Get whether no buttons are being pressed.
     pub fn release_button(&self) -> bool {
         self.state == 0
     }

--- a/src/structs/input.rs
+++ b/src/structs/input.rs
@@ -20,12 +20,11 @@ use winapi::um::wincon::{
 use super::Coord;
 use crate::ScreenBuffer;
 
-/// Describes a keyboard input event in a console INPUT_RECORD structure.
-/// link: [https://docs.microsoft.com/en-us/windows/console/key-event-record-str]
+/// A [keyboard input event](https://docs.microsoft.com/en-us/windows/console/key-event-record-str).
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct KeyEventRecord {
-    /// If the key is pressed, this member is TRUE. Otherwise, this member is
-    /// FALSE (the key is released).
+    /// If the key is pressed, this member is true. Otherwise, this member is
+    /// false (the key is released).
     pub key_down: bool,
     /// The repeat count, which indicates that a key is being held down.
     /// For example, when a key is held down, you might get five events with
@@ -45,8 +44,8 @@ pub struct KeyEventRecord {
 }
 
 impl KeyEventRecord {
-    /// Convert a KEY_EVENT_RECORD to KeyEventRecord. This function is private
-    /// because the KEY_EVENT_RECORD has several union fields for characters
+    /// Convert a `KEY_EVENT_RECORD` to KeyEventRecord. This function is private
+    /// because the `KEY_EVENT_RECORD` has several union fields for characters
     /// (u8 vs u16) that we always interpret as u16. We always use the wide
     /// versions of windows API calls to support this.
     #[inline]
@@ -62,11 +61,16 @@ impl KeyEventRecord {
     }
 }
 
+/// A [mouse input event](https://docs.microsoft.com/en-us/windows/console/mouse-event-record-str).
 #[derive(PartialEq, Debug, Copy, Clone, Eq)]
 pub struct MouseEvent {
+    /// The position of the mouse when the event occurred in cell coordinates.
     pub mouse_position: Coord,
+    /// The state of the mouse's buttons.
     pub button_state: ButtonState,
+    /// The state of the control keys.
     pub control_key_state: ControlKeyState,
+    /// What type of mouse event it is.
     pub event_flags: EventFlags,
 }
 
@@ -90,21 +94,26 @@ impl From<MOUSE_EVENT_RECORD> for MouseEvent {
 /// A bit is 1 if the button was pressed.
 ///
 /// The state can be one of the following:
+///
+/// ```
+/// # enum __ {
 /// Release = 0x0000,
-/// // The leftmost mouse button.
+/// /// The leftmost mouse button.
 /// FromLeft1stButtonPressed = 0x0001,
-/// // The second button from the left.
+/// /// The second button from the left.
 /// FromLeft2ndButtonPressed = 0x0004,
-/// // The third button from the left.
+/// /// The third button from the left.
 /// FromLeft3rdButtonPressed = 0x0008,
-/// // The fourth button from the left.
+/// /// The fourth button from the left.
 /// FromLeft4thButtonPressed = 0x0010,
-/// // The rightmost mouse button.
+/// /// The rightmost mouse button.
 /// RightmostButtonPressed = 0x0002,
-/// // This button state is not recognized.
+/// /// This button state is not recognized.
 /// Unknown = 0x0021,
-/// // The wheel was rotated backward, toward the user; this will only be activated for `MOUSE_WHEELED ` from `dwEventFlags`
+/// /// The wheel was rotated backward, toward the user; this will only be activated for `MOUSE_WHEELED ` from `dwEventFlags`
 /// Negative = 0x0020,
+/// # }
+/// ```
 ///
 /// [Ms Docs](https://docs.microsoft.com/en-us/windows/console/mouse-event-record-str#members)
 #[derive(PartialEq, Debug, Copy, Clone, Eq)]
@@ -121,6 +130,7 @@ impl From<DWORD> for ButtonState {
 }
 
 impl ButtonState {
+    /// Whether no buttons are being pressed.
     pub fn release_button(&self) -> bool {
         self.state == 0
     }
@@ -160,10 +170,26 @@ impl ButtonState {
     }
 }
 
+/// The state of the control keys.
+///
+/// This is a bitmask of the following values.
+///
+/// | Description | Value |
+/// | --- | --- |
+/// | The right alt key is pressed | `0x0001` |
+/// | The left alt key is pressed | `x0002` |
+/// | The right control key is pressed | `0x0004` |
+/// | The left control key is pressed | `x0008` |
+/// | The shift key is pressed | `0x0010` |
+/// | The num lock light is on | `0x0020` |
+/// | The scroll lock light is on | `0x0040` |
+/// | The caps lock light is on | `0x0080` |
+/// | The key is [enhanced](https://docs.microsoft.com/en-us/windows/console/key-event-record-str#remarks) | `0x0100` |
 #[derive(PartialEq, Debug, Copy, Clone, Eq)]
 pub struct ControlKeyState(u32);
 
 impl ControlKeyState {
+    /// Whether the control key has a state.
     pub fn has_state(&self, state: u32) -> bool {
         (state & self.0) != 0
     }
@@ -177,15 +203,15 @@ impl ControlKeyState {
 #[derive(PartialEq, Debug, Copy, Clone, Eq)]
 pub enum EventFlags {
     PressOrRelease = 0x0000,
-    // The second click (button press) of a double-click occurred. The first click is returned as a regular button-press event.
+    /// The second click (button press) of a double-click occurred. The first click is returned as a regular button-press event.
     DoubleClick = 0x0002,
-    // The horizontal mouse wheel was moved.
+    /// The horizontal mouse wheel was moved.
     MouseHwheeled = 0x0008,
-    // If the high word of the dwButtonState member contains a positive value, the wheel was rotated to the right. Otherwise, the wheel was rotated to the left.
+    /// If the high word of the dwButtonState member contains a positive value, the wheel was rotated to the right. Otherwise, the wheel was rotated to the left.
     MouseMoved = 0x0001,
-    // A change in mouse position occurred.
-    // The vertical mouse wheel was moved, if the high word of the dwButtonState member contains a positive value, the wheel was rotated forward, away from the user.
-    // Otherwise, the wheel was rotated backward, toward the user.
+    /// A change in mouse position occurred.
+    /// The vertical mouse wheel was moved, if the high word of the dwButtonState member contains a positive value, the wheel was rotated forward, away from the user.
+    /// Otherwise, the wheel was rotated backward, toward the user.
     MouseWheeled = 0x0004,
 }
 
@@ -203,6 +229,8 @@ impl From<DWORD> for EventFlags {
     }
 }
 
+/// The [size of console screen
+/// buffer](https://docs.microsoft.com/en-us/windows/console/window-buffer-size-record-str).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WindowBufferSizeRecord {
     pub size: Coord,
@@ -217,8 +245,11 @@ impl From<WINDOW_BUFFER_SIZE_RECORD> for WindowBufferSizeRecord {
     }
 }
 
+/// A [focus event](https://docs.microsoft.com/en-us/windows/console/focus-event-record-str). This
+/// is used only internally by Windows and should be ignored.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FocusEventRecord {
+    /// Reserved; do not use.
     pub set_focus: bool,
 }
 
@@ -231,8 +262,11 @@ impl From<FOCUS_EVENT_RECORD> for FocusEventRecord {
     }
 }
 
+/// A [menu event](https://docs.microsoft.com/en-us/windows/console/menu-event-record-str). This is
+/// used only internally by Windows and should be ignored.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MenuEventRecord {
+    /// Reserved; do not use.
     pub command_id: u32,
 }
 
@@ -245,28 +279,22 @@ impl From<MENU_EVENT_RECORD> for MenuEventRecord {
     }
 }
 
-/// Describes an input event in the console input buffer.
+/// An [input event](https://docs.microsoft.com/en-us/windows/console/input-record-str).
+///
 /// These records can be read from the input buffer by using the `ReadConsoleInput`
 /// or `PeekConsoleInput` function, or written to the input buffer by using the
 /// `WriteConsoleInput` function.
-///
-/// [Ms Docs](https://docs.microsoft.com/en-us/windows/console/input-record-str)
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum InputRecord {
-    /// The Event member contains a `KEY_EVENT_RECORD` structure with
-    /// information about a keyboard event.
+    /// A keyboard event occurred.
     KeyEvent(KeyEventRecord),
-    /// The Event member contains a `MOUSE_EVENT_RECORD` structure with
-    /// information about a mouse movement or button press event.
+    /// The mouse was moved or a mouse button was pressed.
     MouseEvent(MouseEvent),
-    /// The Event member contains a `WINDOW_BUFFER_SIZE_RECORD` structure with
-    /// information about the new size of the console screen buffer.
+    /// A console screen buffer was resized.
     WindowBufferSizeEvent(WindowBufferSizeRecord),
-    /// The Event member contains a `FOCUS_EVENT_RECORD` structure. These
-    /// events are used internally and should be ignored.
+    /// A focus event occured. This is used only internally by Windows and should be ignored.
     FocusEvent(FocusEventRecord),
-    /// The Event member contains a `MENU_EVENT_RECORD` structure. These
-    /// events are used internally and should be ignored.
+    /// A menu event occurred. This is used only internally by Windows and should be ignored.
     MenuEvent(MenuEventRecord),
 }
 

--- a/src/structs/size.rs
+++ b/src/structs/size.rs
@@ -1,6 +1,6 @@
 //! This module provides a type that represents some size.
-//! For example, in WinAPi we have `COORD` to represent screen/buffer size but this is a little inconvenient.
-//! This module provides some trait implementations who will make parsing and working whit `COORD` easier.
+//! For example, in WinAPI we have `COORD` to represent screen/buffer size but this is a little inconvenient.
+//! This module provides some trait implementations who will make parsing and working with `COORD` easier.
 
 use winapi::um::wincon::COORD;
 

--- a/src/structs/window_coords.rs
+++ b/src/structs/window_coords.rs
@@ -1,17 +1,19 @@
 //! This module provides a type that represents some rectangle.
-//! For example, in WinAPi we have `SMALL_RECT` to represent a window size but this is a little inconvenient.
-//! This module provides some trait implementations who will make parsing and working whit `COORD` easier.
+//! For example, in WinAPI we have `SMALL_RECT` to represent a window size but this is a little inconvenient.
+//! This module provides some trait implementations who will make parsing and working with `SMALL_RECT` easier.
 
 use winapi::um::wincon::{CONSOLE_SCREEN_BUFFER_INFO, SMALL_RECT};
 
 /// This is a wrapper for the locations of a rectangle.
-///
-/// It has left, right, bottom, top attributes.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub struct WindowPositions {
+    /// The rectangle's offset from the left.
     pub left: i16,
+    /// The rectangle's offset from the right.
     pub right: i16,
+    /// The rectangle's offset from the bottom.
     pub bottom: i16,
+    /// The rectangle's offset from the top.
     pub top: i16,
 }
 


### PR DESCRIPTION
- Use `WinAPI` consistently over other capitalizations.
- Fix Windows docs links that don't work.
- Add documentation for most things.