### PR TITLE
Replace `is_true` with result functions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-pc-windows-gnu"

--- a/examples/screen_buffer.rs
+++ b/examples/screen_buffer.rs
@@ -24,7 +24,7 @@ fn print_screen_buffer_information() -> Result<()> {
 #[cfg(windows)]
 fn multiple_screen_buffers() -> Result<()> {
     // create new screen buffer
-    let screen_buffer = ScreenBuffer::create();
+    let screen_buffer = ScreenBuffer::create()?;
 
     // which to this screen buffer
     screen_buffer.show()

--- a/src/console_mode.rs
+++ b/src/console_mode.rs
@@ -1,8 +1,8 @@
-use std::io::{Error, Result};
+use std::io::Result;
 
 use winapi::um::consoleapi::{GetConsoleMode, SetConsoleMode};
 
-use super::{is_true, Handle, HandleType};
+use super::{result, Handle, HandleType};
 
 /// A wrapper around a screen buffer, focusing on calls to get and set the console mode.
 ///
@@ -32,12 +32,7 @@ impl ConsoleMode {
     /// This wraps
     /// [`SetConsoleMode`](https://docs.microsoft.com/en-us/windows/console/setconsolemode).
     pub fn set_mode(&self, console_mode: u32) -> Result<()> {
-        unsafe {
-            if !is_true(SetConsoleMode(*self.handle, console_mode)) {
-                return Err(Error::last_os_error());
-            }
-        }
-        Ok(())
+        result(unsafe { SetConsoleMode(*self.handle, console_mode) })
     }
 
     /// Get the console mode.
@@ -48,11 +43,7 @@ impl ConsoleMode {
     /// [`GetConsoleMode`](https://docs.microsoft.com/en-us/windows/console/getconsolemode).
     pub fn mode(&self) -> Result<u32> {
         let mut console_mode = 0;
-        unsafe {
-            if !is_true(GetConsoleMode(*self.handle, &mut console_mode)) {
-                return Err(Error::last_os_error());
-            }
-        }
+        result(unsafe { GetConsoleMode(*self.handle, &mut console_mode) })?;
         Ok(console_mode)
     }
 }

--- a/src/csbi.rs
+++ b/src/csbi.rs
@@ -47,10 +47,10 @@ impl ScreenBufferInfo {
     ///
     /// Will calculate the width and height from `srWindow` and convert it into a [`Size`].
     pub fn terminal_size(&self) -> Size {
-        (Size::new(
+        Size::new(
             self.0.srWindow.Right - self.0.srWindow.Left,
             self.0.srWindow.Bottom - self.0.srWindow.Top,
-        ))
+        )
     }
 
     /// Get the position and size of the terminal display window.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,13 @@
 #![cfg(windows)]
 #![deny(unused_imports)]
 
+use std::io;
+
+use winapi::shared::minwindef::BOOL;
+use winapi::um::handleapi::INVALID_HANDLE_VALUE;
+use winapi::um::wincontypes::COORD;
+use winapi::um::winnt::HANDLE;
+
 pub use self::{
     console::Console,
     console_mode::ConsoleMode,
@@ -22,10 +29,43 @@ mod screen_buffer;
 mod semaphore;
 mod structs;
 
-/// Parses the given integer to an bool by checking if the value is 0 or 1.
-/// This is currently used for checking if a WinAPI called succeeded, this might be moved into a macro at some time.
-/// So please don't use this :(.
-#[inline(always)]
-pub fn is_true(value: i32) -> bool {
-    value != 0
+/// Get the result of a call to WinAPI as an [`io::Result`].
+#[inline]
+pub fn result(return_value: BOOL) -> io::Result<()> {
+    if return_value != 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// Get the result of a call to WinAPI that returns a
+/// [`COORD`](https://docs.microsoft.com/en-us/windows/console/coord-str) as an [`io::Result`].
+#[inline]
+pub fn coord_result(return_value: COORD) -> io::Result<Coord> {
+    if return_value.X != 0 && return_value.Y != 0 {
+        Ok(Coord::from(return_value))
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// Get the result of a call to WinAPI that returns a handle or `INVALID_HANDLE_VALUE`.
+#[inline]
+pub fn handle_result(return_value: HANDLE) -> io::Result<HANDLE> {
+    if return_value != INVALID_HANDLE_VALUE {
+        Ok(return_value)
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// Get the result of a call to WinAPI that returns a handle or `NULL`.
+#[inline]
+pub fn nonnull_handle_result(return_value: HANDLE) -> io::Result<HANDLE> {
+    if return_value.is_null() {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(return_value)
+    }
 }

--- a/src/screen_buffer.rs
+++ b/src/screen_buffer.rs
@@ -1,6 +1,6 @@
 //! This contains the logic for working with the console buffer.
 
-use std::io::{Error, Result};
+use std::io::Result;
 use std::mem::size_of;
 
 use winapi::{
@@ -16,7 +16,7 @@ use winapi::{
     },
 };
 
-use super::{is_true, Handle, HandleType, ScreenBufferInfo};
+use super::{handle_result, result, Handle, HandleType, ScreenBufferInfo};
 
 /// A wrapper around a screen buffer.
 #[derive(Clone, Debug)]
@@ -41,26 +41,26 @@ impl ScreenBuffer {
     ///
     /// This wraps
     /// [`CreateConsoleScreenBuffer`](https://docs.microsoft.com/en-us/windows/console/createconsolescreenbuffer)
-    pub fn create() -> ScreenBuffer {
-        let mut security_attr: SECURITY_ATTRIBUTES = SECURITY_ATTRIBUTES {
+    pub fn create() -> Result<ScreenBuffer> {
+        let security_attr: SECURITY_ATTRIBUTES = SECURITY_ATTRIBUTES {
             nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
             lpSecurityDescriptor: NULL,
             bInheritHandle: TRUE,
         };
 
-        unsafe {
-            let new_screen_buffer = CreateConsoleScreenBuffer(
+        let new_screen_buffer = handle_result(unsafe {
+            CreateConsoleScreenBuffer(
                 GENERIC_READ |           // read/write access
                     GENERIC_WRITE,
                 FILE_SHARE_READ | FILE_SHARE_WRITE, // shared
-                &mut security_attr,                 // default security attributes
+                &security_attr,                     // default security attributes
                 CONSOLE_TEXTMODE_BUFFER,            // must be TEXTMODE
                 NULL,
-            );
-            ScreenBuffer {
-                handle: Handle::from_raw(new_screen_buffer),
-            }
-        }
+            )
+        })?;
+        Ok(ScreenBuffer {
+            handle: unsafe { Handle::from_raw(new_screen_buffer) },
+        })
     }
 
     /// Set this screen buffer to the current one.
@@ -68,12 +68,7 @@ impl ScreenBuffer {
     /// This wraps
     /// [`SetConsoleActiveScreenBuffer`](https://docs.microsoft.com/en-us/windows/console/setconsoleactivescreenbuffer).
     pub fn show(&self) -> Result<()> {
-        unsafe {
-            if !is_true(SetConsoleActiveScreenBuffer(*self.handle)) {
-                return Err(Error::last_os_error());
-            }
-        }
-        Ok(())
+        result(unsafe { SetConsoleActiveScreenBuffer(*self.handle) })
     }
 
     /// Get the screen buffer information like terminal size, cursor position, buffer size.
@@ -82,13 +77,7 @@ impl ScreenBuffer {
     /// [`GetConsoleScreenBufferInfo`](https://docs.microsoft.com/en-us/windows/console/getconsolescreenbufferinfo).
     pub fn info(&self) -> Result<ScreenBufferInfo> {
         let mut csbi = ScreenBufferInfo::new();
-
-        unsafe {
-            if !is_true(GetConsoleScreenBufferInfo(*self.handle, &mut csbi.0)) {
-                return Err(Error::last_os_error());
-            }
-        }
-
+        result(unsafe { GetConsoleScreenBufferInfo(*self.handle, &mut csbi.0) })?;
         Ok(csbi)
     }
 
@@ -97,20 +86,12 @@ impl ScreenBuffer {
     /// This wraps
     /// [`SetConsoleScreenBufferSize`](https://docs.microsoft.com/en-us/windows/console/setconsolescreenbuffersize).
     pub fn set_size(&self, x: i16, y: i16) -> Result<()> {
-        unsafe {
-            if !is_true(SetConsoleScreenBufferSize(
-                *self.handle,
-                COORD { X: x, Y: y },
-            )) {
-                return Err(Error::last_os_error());
-            }
-        }
-        Ok(())
+        result(unsafe { SetConsoleScreenBufferSize(*self.handle, COORD { X: x, Y: y }) })
     }
 
     /// Get the underlying raw `HANDLE` used by this type to execute with.
     pub fn handle(&self) -> &Handle {
-        return &self.handle;
+        &self.handle
     }
 }
 


### PR DESCRIPTION
This PR replaces the `is_true` function with functions that take the return value of a WinAPI call and return an `io::Result`. This allows for much more concise code when calling Windows APIs. I don't know whether these function should be private though, since ideally this crate would abstract enough that Crossterm wouldn't have to make any WinAPI calls directly.

I also fixed `largest_window_size` and `ScreenBuffer::create` which were incorrectly infallible.