### PR TITLE
Fix input crash while using windows terminal

### DIFF
--- a/src/structs/input.rs
+++ b/src/structs/input.rs
@@ -220,6 +220,8 @@ impl From<DWORD> for EventFlags {
     fn from(event: DWORD) -> Self {
         match event {
             0x0000 => EventFlags::PressOrRelease,
+            //Only triggered using Windows Terminal while moving and clicking the mouse.
+            0x0003 => EventFlags::PressOrRelease,
             0x0002 => EventFlags::DoubleClick,
             0x0008 => EventFlags::MouseHwheeled,
             0x0001 => EventFlags::MouseMoved,


### PR DESCRIPTION
Windows terminal has a seperate event for clicking the mouse while moving the cursor. Without handling the case, the program will panic. 
```
Event::Mouse(MouseEvent { kind: Moved, column: 35, row: 26, modifiers: NONE })
Event::Mouse(MouseEvent { kind: Down(Left), column: 35, row: 26, modifiers: NONE })
thread 'main' panicked at 'Event flag 3 does not exist.', crossterm-winapi\src\structs\input.rs:229:18
```