### PR TITLE
Migrating to windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,6 @@ readme = "README.md"
 edition = "2018"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.8", features = [
-        "winbase",
-        "consoleapi",
-        "processenv",
-        "handleapi",
-        "synchapi",
-        "impl-default",
-] }
 windows-sys = { version = "0.42.0", features = [
         "Win32_Foundation",
         "Win32_Security",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,22 @@ readme = "README.md"
 edition = "2018"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version =  "0.3.8", features = ["winbase", "consoleapi", "processenv", "handleapi", "synchapi", "impl-default"] }
+winapi = { version = "0.3.8", features = [
+        "winbase",
+        "consoleapi",
+        "processenv",
+        "handleapi",
+        "synchapi",
+        "impl-default",
+] }
+windows-sys = { version = "0.42.0", features = [
+        "Win32_Foundation",
+        "Win32_Security",
+        "Win32_System_Threading",
+        "Win32_System_Console",
+        "Win32_Storage_FileSystem",
+        "Win32_System_SystemServices",
+] }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/src/console_mode.rs
+++ b/src/console_mode.rs
@@ -1,6 +1,6 @@
 use std::io::Result;
 
-use winapi::um::consoleapi::{GetConsoleMode, SetConsoleMode};
+use windows_sys::Win32::System::Console::{GetConsoleMode, SetConsoleMode};
 
 use super::{result, Handle, HandleType};
 

--- a/src/csbi.rs
+++ b/src/csbi.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::mem::zeroed;
 
-use winapi::um::wincon::CONSOLE_SCREEN_BUFFER_INFO;
+use windows_sys::Win32::System::Console::CONSOLE_SCREEN_BUFFER_INFO;
 
 use super::{Coord, Size, WindowPositions};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,8 @@
 
 use std::io;
 
-use winapi::shared::minwindef::BOOL;
-use winapi::um::handleapi::INVALID_HANDLE_VALUE;
-use winapi::um::wincontypes::COORD;
-use winapi::um::winnt::HANDLE;
+use windows_sys::Win32::Foundation::{BOOL, HANDLE, INVALID_HANDLE_VALUE};
+use windows_sys::Win32::System::Console::COORD;
 
 pub use self::{
     console::Console,
@@ -63,7 +61,7 @@ pub fn handle_result(return_value: HANDLE) -> io::Result<HANDLE> {
 /// Get the result of a call to WinAPI that returns a handle or `NULL`.
 #[inline]
 pub fn nonnull_handle_result(return_value: HANDLE) -> io::Result<HANDLE> {
-    if return_value.is_null() {
+    if return_value == 0 {
         Err(io::Error::last_os_error())
     } else {
         Ok(return_value)

--- a/src/screen_buffer.rs
+++ b/src/screen_buffer.rs
@@ -3,18 +3,14 @@
 use std::io::Result;
 use std::mem::size_of;
 
-use winapi::{
-    shared::minwindef::TRUE,
-    shared::ntdef::NULL,
-    um::{
-        minwinbase::SECURITY_ATTRIBUTES,
-        wincon::{
-            CreateConsoleScreenBuffer, GetConsoleScreenBufferInfo, SetConsoleActiveScreenBuffer,
-            SetConsoleScreenBufferSize, CONSOLE_TEXTMODE_BUFFER, COORD,
-        },
-        winnt::{FILE_SHARE_READ, FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE},
-    },
+use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
+use windows_sys::Win32::Storage::FileSystem::{FILE_SHARE_READ, FILE_SHARE_WRITE};
+use windows_sys::Win32::System::Console::{
+    CreateConsoleScreenBuffer, GetConsoleScreenBufferInfo, SetConsoleActiveScreenBuffer,
+    SetConsoleScreenBufferSize, CONSOLE_TEXTMODE_BUFFER, COORD,
 };
+use windows_sys::Win32::System::SystemServices::{GENERIC_READ, GENERIC_WRITE};
+pub const TRUE: ::windows_sys::Win32::Foundation::BOOL = 1;
 
 use super::{handle_result, result, Handle, HandleType, ScreenBufferInfo};
 
@@ -44,7 +40,7 @@ impl ScreenBuffer {
     pub fn create() -> Result<ScreenBuffer> {
         let security_attr: SECURITY_ATTRIBUTES = SECURITY_ATTRIBUTES {
             nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
-            lpSecurityDescriptor: NULL,
+            lpSecurityDescriptor: ::std::ptr::null_mut(),
             bInheritHandle: TRUE,
         };
 
@@ -55,8 +51,8 @@ impl ScreenBuffer {
                 FILE_SHARE_READ | FILE_SHARE_WRITE, // shared
                 &security_attr,                     // default security attributes
                 CONSOLE_TEXTMODE_BUFFER,            // must be TEXTMODE
-                NULL,
-            )
+                ::std::ptr::null_mut(),
+            ) as _
         })?;
         Ok(ScreenBuffer {
             handle: unsafe { Handle::from_raw(new_screen_buffer) },

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -1,6 +1,6 @@
 use std::{io, ptr};
 
-use winapi::um::synchapi::{CreateSemaphoreW, ReleaseSemaphore};
+use windows_sys::Win32::System::Threading::{CreateSemaphoreW, ReleaseSemaphore};
 
 use crate::{nonnull_handle_result, result, Handle};
 
@@ -14,9 +14,8 @@ impl Semaphore {
     /// This wraps
     /// [`CreateSemaphoreW`](https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createsemaphorew).
     pub fn new() -> io::Result<Self> {
-        let handle = nonnull_handle_result(unsafe {
-            CreateSemaphoreW(ptr::null_mut(), 0, 1, ptr::null_mut())
-        })?;
+        let handle =
+            nonnull_handle_result(unsafe { CreateSemaphoreW(ptr::null(), 0, 1, ptr::null()) })?;
 
         let handle = unsafe { Handle::from_raw(handle) };
         Ok(Self(handle))

--- a/src/structs/coord.rs
+++ b/src/structs/coord.rs
@@ -2,7 +2,7 @@
 //! For example, in WinAPI we have `COORD` which looks and feels inconvenient.
 //! This module provides also some trait implementations who will make parsing and working with `COORD` easier.
 
-use winapi::um::wincon::COORD;
+use windows_sys::Win32::System::Console::COORD;
 
 /// This is type represents the position of something on a certain 'x' and 'y'.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd)]

--- a/src/structs/input.rs
+++ b/src/structs/input.rs
@@ -9,8 +9,7 @@
 //! - `InputEventType`
 //! - `INPUT_RECORD`
 
-use winapi::shared::minwindef::DWORD;
-use winapi::um::wincon::{
+use windows_sys::Win32::System::Console::{
     FOCUS_EVENT, FOCUS_EVENT_RECORD, FROM_LEFT_1ST_BUTTON_PRESSED, FROM_LEFT_2ND_BUTTON_PRESSED,
     FROM_LEFT_3RD_BUTTON_PRESSED, FROM_LEFT_4TH_BUTTON_PRESSED, INPUT_RECORD, KEY_EVENT,
     KEY_EVENT_RECORD, MENU_EVENT, MENU_EVENT_RECORD, MOUSE_EVENT, MOUSE_EVENT_RECORD,
@@ -55,7 +54,7 @@ impl KeyEventRecord {
             repeat_count: record.wRepeatCount,
             virtual_key_code: record.wVirtualKeyCode,
             virtual_scan_code: record.wVirtualScanCode,
-            u_char: unsafe { *record.uChar.UnicodeChar() },
+            u_char: unsafe { record.uChar.UnicodeChar },
             control_key_state: ControlKeyState(record.dwControlKeyState),
         }
     }
@@ -121,9 +120,9 @@ pub struct ButtonState {
     state: i32,
 }
 
-impl From<DWORD> for ButtonState {
+impl From<u32> for ButtonState {
     #[inline]
-    fn from(event: DWORD) -> Self {
+    fn from(event: u32) -> Self {
         let state = event as i32;
         ButtonState { state }
     }
@@ -218,8 +217,8 @@ pub enum EventFlags {
 }
 
 // TODO: Replace with TryFrom.
-impl From<DWORD> for EventFlags {
-    fn from(event: DWORD) -> Self {
+impl From<u32> for EventFlags {
+    fn from(event: u32) -> Self {
         match event {
             0x0000 => EventFlags::PressOrRelease,
             0x0002 => EventFlags::DoubleClick,
@@ -303,14 +302,14 @@ pub enum InputRecord {
 impl From<INPUT_RECORD> for InputRecord {
     #[inline]
     fn from(record: INPUT_RECORD) -> Self {
-        match record.EventType {
+        match record.EventType as u32 {
             KEY_EVENT => InputRecord::KeyEvent(KeyEventRecord::from_winapi(unsafe {
-                record.Event.KeyEvent()
+                &record.Event.KeyEvent
             })),
-            MOUSE_EVENT => InputRecord::MouseEvent(unsafe { *record.Event.MouseEvent() }.into()),
+            MOUSE_EVENT => InputRecord::MouseEvent(unsafe { record.Event.MouseEvent }.into()),
             WINDOW_BUFFER_SIZE_EVENT => InputRecord::WindowBufferSizeEvent({
                 let mut buffer =
-                    unsafe { WindowBufferSizeRecord::from(*record.Event.WindowBufferSizeEvent()) };
+                    unsafe { WindowBufferSizeRecord::from(record.Event.WindowBufferSizeEvent) };
                 let window = ScreenBuffer::current().unwrap().info().unwrap();
                 let screen_size = window.terminal_size();
 
@@ -319,8 +318,8 @@ impl From<INPUT_RECORD> for InputRecord {
 
                 buffer
             }),
-            FOCUS_EVENT => InputRecord::FocusEvent(unsafe { *record.Event.FocusEvent() }.into()),
-            MENU_EVENT => InputRecord::MenuEvent(unsafe { *record.Event.MenuEvent() }.into()),
+            FOCUS_EVENT => InputRecord::FocusEvent(unsafe { record.Event.FocusEvent }.into()),
+            MENU_EVENT => InputRecord::MenuEvent(unsafe { record.Event.MenuEvent }.into()),
             code => panic!("Unexpected INPUT_RECORD EventType: {}", code),
         }
     }

--- a/src/structs/size.rs
+++ b/src/structs/size.rs
@@ -2,7 +2,7 @@
 //! For example, in WinAPI we have `COORD` to represent screen/buffer size but this is a little inconvenient.
 //! This module provides some trait implementations who will make parsing and working with `COORD` easier.
 
-use winapi::um::wincon::COORD;
+use windows_sys::Win32::System::Console::COORD;
 
 /// This is type represents the size of something in width and height.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]

--- a/src/structs/window_coords.rs
+++ b/src/structs/window_coords.rs
@@ -2,7 +2,7 @@
 //! For example, in WinAPI we have `SMALL_RECT` to represent a window size but this is a little inconvenient.
 //! This module provides some trait implementations who will make parsing and working with `SMALL_RECT` easier.
 
-use winapi::um::wincon::{CONSOLE_SCREEN_BUFFER_INFO, SMALL_RECT};
+use windows_sys::Win32::System::Console::{CONSOLE_SCREEN_BUFFER_INFO, SMALL_RECT};
 
 /// This is a wrapper for the locations of a rectangle.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]


### PR DESCRIPTION
Attempt at moving to windows-sys for win32 api

Please do as you see fit, winapi still seems to be working fine for crossterm's use at the moment.