### PR TITLE
add font_info() to ScreenBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This crate provides some abstractions over reading input, console screen buffer,
 The following WinAPI calls:
 
 - CONSOLE_SCREEN_BUFFER_INFO (used to extract information like cursor pos, terminal size etc.)
+- CONSOLE_FONT_INFO (used to extract font info like size)
 - HANDLE (the handle needed to run functions from WinAPI)
 - SetConsoleActiveScreenBuffer (activate an other screen buffer)
 - Set/GetConsoleMode (e.g. console modes like disabling output)

--- a/examples/screen_buffer.rs
+++ b/examples/screen_buffer.rs
@@ -7,6 +7,9 @@ use std::io::Result;
 use crossterm_winapi::ScreenBuffer;
 
 #[cfg(windows)]
+use crossterm_winapi::FontInfo;
+
+#[cfg(windows)]
 fn print_screen_buffer_information() -> Result<()> {
     let screen_buffer = ScreenBuffer::current()?;
 
@@ -17,6 +20,9 @@ fn print_screen_buffer_information() -> Result<()> {
     println!("attributes: {:?}", csbi.attributes());
     println!("terminal window dimentions {:?}", csbi.terminal_window());
     println!("terminal size {:?}", csbi.terminal_size());
+
+    let cfi: FontInfo = screen_buffer.font_info()?;
+    println!("font size {:?}", cfi.size());
 
     Ok(())
 }

--- a/src/cfi.rs
+++ b/src/cfi.rs
@@ -1,0 +1,42 @@
+use std::fmt;
+use std::mem::zeroed;
+
+use winapi::um::wincontypes::CONSOLE_FONT_INFO;
+
+use crate::Size;
+
+/// Information about the font.
+///
+/// This wraps
+/// [`CONSOLE_FONT_INFO`](https://learn.microsoft.com/en-us/windows/console/console-font-info-str).
+#[derive(Clone)]
+pub struct FontInfo(pub CONSOLE_FONT_INFO);
+
+// TODO: replace this with a derive ASAP
+impl fmt::Debug for FontInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("FontInfo")
+            .field("dwFontSize", &self.size())
+            .field("nFont", &self.index())
+            .finish()
+    }
+}
+
+impl FontInfo {
+    /// Create a new font info without all zeroed properties.
+    pub fn new() -> FontInfo {
+        FontInfo(unsafe { zeroed() })
+    }
+
+    /// Get the size of the font.
+    ///
+    /// Will take `dwFontSize` from the current font info and convert it into a [`Size`].
+    pub fn size(&self) -> Size {
+        Size::from(self.0.dwFontSize)
+    }
+
+    /// Get the index of the font in the system's console font table.
+    pub fn index(&self) -> u32 {
+        self.0.nFont
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use winapi::um::wincontypes::COORD;
 use winapi::um::winnt::HANDLE;
 
 pub use self::{
+    cfi::FontInfo,
     console::Console,
     console_mode::ConsoleMode,
     csbi::ScreenBufferInfo,
@@ -21,6 +22,7 @@ pub use self::{
     },
 };
 
+mod cfi;
 mod console;
 mod console_mode;
 mod csbi;

--- a/src/screen_buffer.rs
+++ b/src/screen_buffer.rs
@@ -9,14 +9,15 @@ use winapi::{
     um::{
         minwinbase::SECURITY_ATTRIBUTES,
         wincon::{
-            CreateConsoleScreenBuffer, GetConsoleScreenBufferInfo, SetConsoleActiveScreenBuffer,
-            SetConsoleScreenBufferSize, CONSOLE_TEXTMODE_BUFFER, COORD,
+            CreateConsoleScreenBuffer, GetConsoleScreenBufferInfo, GetCurrentConsoleFont,
+            SetConsoleActiveScreenBuffer, SetConsoleScreenBufferSize, CONSOLE_TEXTMODE_BUFFER,
+            COORD,
         },
         winnt::{FILE_SHARE_READ, FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE},
     },
 };
 
-use super::{handle_result, result, Handle, HandleType, ScreenBufferInfo};
+use super::{handle_result, result, FontInfo, Handle, HandleType, ScreenBufferInfo};
 
 /// A wrapper around a screen buffer.
 #[derive(Clone, Debug)]
@@ -79,6 +80,16 @@ impl ScreenBuffer {
         let mut csbi = ScreenBufferInfo::new();
         result(unsafe { GetConsoleScreenBufferInfo(*self.handle, &mut csbi.0) })?;
         Ok(csbi)
+    }
+
+    /// Get the current font information like size and font index.
+    ///
+    /// This wraps
+    /// [`GetConsoleFontSize`](https://learn.microsoft.com/en-us/windows/console/getconsolefontsize).
+    pub fn font_info(&self) -> Result<FontInfo> {
+        let mut fi = FontInfo::new();
+        result(unsafe { GetCurrentConsoleFont(*self.handle, 0, &mut fi.0) })?;
+        Ok(fi)
     }
 
     /// Set the console screen buffer size to the given size.


### PR DESCRIPTION
Gets the font size, which can then be used by crossterm to query font-size / terminal-pixel-size. CONSOLE_SCREEN_BUFFER_INFO only contains cols/rows.