### PR TITLE
Use windows crate instead of winapi

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  MSRV: "1.56.0"
+  MSRV: "1.62.0"
 
 # ensure that the workflow is only triggered once per PR, subsequent pushes to the PR will cancel
 # and restart the workflow. See https://docs.github.com/en/actions/using-jobs/using-concurrency
@@ -74,7 +74,7 @@ jobs:
           RUSTDOCFLAGS: --cfg docsrs
   msrv:
     # check that we can build using the minimal rust version that is specified by this crate
-    name: check (1.56.0)
+    name: check msrv
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,88 @@
+name: Check
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+  MSRV: "1.56.0"
+
+# ensure that the workflow is only triggered once per PR, subsequent pushes to the PR will cancel
+# and restart the workflow. See https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  fmt:
+    name: fmt (stable)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+          targets: x86_64-pc-windows-msvc,x86_64-pc-windows-gnu
+      - name: Run cargo fmt
+        run: cargo fmt -- --check
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+  clippy:
+    name: clippy (${{ matrix.toolchain }})
+    runs-on: windows-latest
+    permissions:
+      checks: write
+    strategy:
+      fail-fast: false
+      matrix:
+        # Get early warnings about new lints introduced in the beta channel
+        toolchain: [stable, beta]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: clippy
+          targets: x86_64-pc-windows-msvc,x86_64-pc-windows-gnu
+      - name: Run clippy action
+        uses: clechasseur/rs-clippy-check@v3
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+  doc:
+    # run docs generation on nightly rather than stable. This enables features like
+    # https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html which allows an
+    # API be documented as only available in some specific platforms.
+    name: doc (nightly)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: x86_64-pc-windows-msvc,x86_64-pc-windows-gnu
+      - name: Run cargo doc
+        run: cargo doc --no-deps --all-features
+        env:
+          RUSTDOCFLAGS: --cfg docsrs
+  msrv:
+    # check that we can build using the minimal rust version that is specified by this crate
+    name: check (1.56.0)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust ${{ env.MSRV }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.MSRV }}
+          targets: x86_64-pc-windows-msvc,x86_64-pc-windows-gnu
+      - name: cargo +${{ env.MSRV }} check
+        run: cargo check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,9 @@ jobs:
     name: Test (${{ matrix.toolchain }})
     strategy:
       matrix:
-        # run on stable and beta to ensure that tests won't break on the next version of the rust
-        # toolchain
-        toolchain: [stable, beta, 1.56.0]
+        # run on beta to ensure that tests won't break on the next version of the rust toolchain
+        # run on msrv to ensure that tests won't break on the minimum supported version of the rust
+        toolchain: [1.62.0, stable, beta]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,8 @@ jobs:
     name: Test (${{ matrix.toolchain }})
     strategy:
       matrix:
-        # run on beta to ensure that tests won't break on the next version of the rust toolchain
-        # run on msrv to ensure that tests won't break on the minimum supported version of the rust
+        # run on stable and beta to ensure that tests won't break on the next version of the rust
+        # toolchain
         toolchain: [1.62.0, stable, beta]
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,93 @@
+name: Test
+# This is the main CI workflow that runs the test suite on all pushes to main and all pull requests.
+# It runs the following jobs:
+# - test: runs the test suite on ubuntu with stable and beta rust toolchains
+# - minimal: runs the test suite with the minimal versions of the dependencies that satisfy the
+#   requirements of this crate, and its dependencies
+# See check.yml for information about how the concurrency cancellation and workflow triggering works
+# and for the fmt, clippy, doc, and msrv jobs.
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+# ensure that the workflow is only triggered once per PR, subsequent pushes to the PR will cancel
+# and restart the workflow. See https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: windows-latest
+    name: Test (${{ matrix.toolchain }})
+    strategy:
+      matrix:
+        # run on stable and beta to ensure that tests won't break on the next version of the rust
+        # toolchain
+        toolchain: [stable, beta, 1.56.0]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust ${{ matrix.toolchain }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          targets: x86_64-pc-windows-msvc,x86_64-pc-windows-gnu
+      # Generate a lockfile to use if one is not checked in. This makes the next step able to
+      # run regardless of whether a lockfile is checked in or not.
+      - name: cargo generate-lockfile
+        if: hashFiles('Cargo.lock') == ''
+        run: cargo generate-lockfile
+      - name: cargo test --locked
+        run: cargo test --locked --all-features --all-targets
+      - name: cargo test --doc
+        run: cargo test --locked --all-features --doc
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+  # This action chooses the oldest version of the dependencies permitted by Cargo.toml to ensure
+  # that this crate is compatible with the minimal version that this crate and its dependencies
+  # require. This will pickup issues where this create relies on functionality that was introduced
+  # later than the actual version specified (e.g., when we choose just a major version, but a
+  # method was added after this version).
+  #
+  # This particular check can be difficult to get to succeed as often transitive dependencies may
+  # be incorrectly specified (e.g., a dependency specifies 1.0 but really requires 1.1.5). There
+  # is an alternative flag available -Zdirect-minimal-versions that uses the minimal versions for
+  # direct dependencies of this crate, while selecting the maximal versions for the transitive
+  # dependencies. Alternatively, you can add a line in your Cargo.toml to artificially increase
+  # the minimal dependency, which you do with e.g.:
+  # ```toml
+  # # for minimal-versions
+  # [target.'cfg(any())'.dependencies]
+  # openssl = { version = "0.10.55", optional = true } # needed to allow foo to build with -Zminimal-versions
+  # ```
+  # The optional = true is necessary in case that dependency isn't otherwise transitively required
+  # by your library, and the target bit is so that this dependency edge never actually affects
+  # Cargo build order. See also
+  # https://github.com/jonhoo/fantoccini/blob/fde336472b712bc7ebf5b4e772023a7ba71b2262/Cargo.toml#L47-L49.
+  # This action is run on ubuntu with the stable toolchain, as it is not expected to fail
+  minimal-versions:
+    runs-on: windows-latest
+    name: Check minimal-versions
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc,x86_64-pc-windows-gnu
+      - name: Install Rust nightly (for -Zdirect-minimal-versions)
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: x86_64-pc-windows-msvc,x86_64-pc-windows-gnu
+      - name: rustup default stable
+        run: rustup default stable
+      - name: cargo update -Zdirect-minimal-versions
+        run: cargo +nightly update -Zdirect-minimal-versions
+      - name: cargo test
+        run: cargo test --locked --all-features --all-targets
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ edition = "2021"
 rust-version = "1.62.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.8", features = [
-    "winbase",
-    "consoleapi",
-    "processenv",
-    "handleapi",
-    "synchapi",
-    "impl-default",
+# Note that 0.56.0 is the last version that supports Rust 1.62.0, the next version requires Rust
+# 1.70.0. This would prevent crossterm from being able to compile this on the stable version of
+# Debian (which ships with Rust 1.63.0).
+windows = { version = "0.56.0", features = [
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Console",
+    "Win32_System_Threading",
 ] }
-
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,18 @@ license = "MIT"
 keywords = ["winapi", "abstractions", "crossterm", "windows", "screen_buffer"]
 exclude = ["target", "Cargo.lock"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
+rust-version = "1.62.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version =  "0.3.8", features = ["winbase", "consoleapi", "processenv", "handleapi", "synchapi", "impl-default"] }
+winapi = { version = "0.3.8", features = [
+    "winbase",
+    "consoleapi",
+    "processenv",
+    "handleapi",
+    "synchapi",
+    "impl-default",
+] }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/examples/coloring_example.rs
+++ b/examples/coloring_example.rs
@@ -42,8 +42,8 @@ fn set_foreground_color() -> Result<()> {
 
     // background intensity is a separate value in attrs,
     // wee need to check if this was applied to the current bg color.
-    if (attrs & 0x0080 as u16) != 0 {
-        color = color | 0x0080 as u16;
+    if (attrs & 0x0080_u16) != 0 {
+        color |= 0x0080_u16;
     }
 
     // set the console text attribute to the new color value.

--- a/src/cfi.rs
+++ b/src/cfi.rs
@@ -1,7 +1,6 @@
 use std::fmt;
-use std::mem::zeroed;
 
-use winapi::um::wincontypes::CONSOLE_FONT_INFO;
+use windows::Win32::System::Console::CONSOLE_FONT_INFO;
 
 use crate::Size;
 
@@ -23,9 +22,9 @@ impl fmt::Debug for FontInfo {
 }
 
 impl FontInfo {
-    /// Create a new font info without all zeroed properties.
+    /// Create a new font info with default (zeroed) properties.
     pub fn new() -> FontInfo {
-        FontInfo(unsafe { zeroed() })
+        FontInfo(CONSOLE_FONT_INFO::default())
     }
 
     /// Get the size of the font.
@@ -38,5 +37,11 @@ impl FontInfo {
     /// Get the index of the font in the system's console font table.
     pub fn index(&self) -> u32 {
         self.0.nFont
+    }
+}
+
+impl Default for FontInfo {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/console_mode.rs
+++ b/src/console_mode.rs
@@ -1,8 +1,8 @@
 use std::io::Result;
 
-use winapi::um::consoleapi::{GetConsoleMode, SetConsoleMode};
+use windows::Win32::System::Console::{GetConsoleMode, SetConsoleMode, CONSOLE_MODE};
 
-use super::{result, Handle, HandleType};
+use super::{Handle, HandleType};
 
 /// A wrapper around a screen buffer, focusing on calls to get and set the console mode.
 ///
@@ -32,7 +32,8 @@ impl ConsoleMode {
     /// This wraps
     /// [`SetConsoleMode`](https://docs.microsoft.com/en-us/windows/console/setconsolemode).
     pub fn set_mode(&self, console_mode: u32) -> Result<()> {
-        result(unsafe { SetConsoleMode(*self.handle, console_mode) })
+        unsafe { SetConsoleMode(*self.handle, CONSOLE_MODE(console_mode)) }?;
+        Ok(())
     }
 
     /// Get the console mode.
@@ -42,9 +43,9 @@ impl ConsoleMode {
     /// This wraps
     /// [`GetConsoleMode`](https://docs.microsoft.com/en-us/windows/console/getconsolemode).
     pub fn mode(&self) -> Result<u32> {
-        let mut console_mode = 0;
-        result(unsafe { GetConsoleMode(*self.handle, &mut console_mode) })?;
-        Ok(console_mode)
+        let mut console_mode = CONSOLE_MODE(0);
+        unsafe { GetConsoleMode(*self.handle, &mut console_mode) }?;
+        Ok(console_mode.0)
     }
 }
 

--- a/src/csbi.rs
+++ b/src/csbi.rs
@@ -1,7 +1,6 @@
 use std::fmt;
-use std::mem::zeroed;
 
-use winapi::um::wincon::CONSOLE_SCREEN_BUFFER_INFO;
+use windows::Win32::System::Console::CONSOLE_SCREEN_BUFFER_INFO;
 
 use super::{Coord, Size, WindowPositions};
 
@@ -31,9 +30,9 @@ impl fmt::Debug for ScreenBufferInfo {
 }
 
 impl ScreenBufferInfo {
-    /// Create a new console screen buffer without all zeroed properties.
+    /// Create a new console screen buffer with default (zeroed) properties.
     pub fn new() -> ScreenBufferInfo {
-        ScreenBufferInfo(unsafe { zeroed() })
+        ScreenBufferInfo(CONSOLE_SCREEN_BUFFER_INFO::default())
     }
 
     /// Get the size of the screen buffer.
@@ -64,7 +63,7 @@ impl ScreenBufferInfo {
     ///
     /// Will take `wAttributes` from the current screen buffer.
     pub fn attributes(&self) -> u16 {
-        self.0.wAttributes
+        self.0.wAttributes.0
     }
 
     /// Get the current column and row of the terminal cursor in the screen buffer.
@@ -72,6 +71,12 @@ impl ScreenBufferInfo {
     /// Will take `dwCursorPosition` from the current screen buffer.
     pub fn cursor_pos(&self) -> Coord {
         Coord::from(self.0.dwCursorPosition)
+    }
+}
+
+impl Default for ScreenBufferInfo {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,7 @@
 
 use std::io;
 
-use winapi::shared::minwindef::BOOL;
-use winapi::um::handleapi::INVALID_HANDLE_VALUE;
-use winapi::um::wincontypes::COORD;
-use winapi::um::winnt::HANDLE;
+use windows::Win32::System::Console::COORD;
 
 pub use self::{
     cfi::FontInfo,
@@ -31,16 +28,6 @@ mod screen_buffer;
 mod semaphore;
 mod structs;
 
-/// Get the result of a call to WinAPI as an [`io::Result`].
-#[inline]
-pub fn result(return_value: BOOL) -> io::Result<()> {
-    if return_value != 0 {
-        Ok(())
-    } else {
-        Err(io::Error::last_os_error())
-    }
-}
-
 /// Get the result of a call to WinAPI that returns a
 /// [`COORD`](https://docs.microsoft.com/en-us/windows/console/coord-str) as an [`io::Result`].
 #[inline]
@@ -49,25 +36,5 @@ pub fn coord_result(return_value: COORD) -> io::Result<Coord> {
         Ok(Coord::from(return_value))
     } else {
         Err(io::Error::last_os_error())
-    }
-}
-
-/// Get the result of a call to WinAPI that returns a handle or `INVALID_HANDLE_VALUE`.
-#[inline]
-pub fn handle_result(return_value: HANDLE) -> io::Result<HANDLE> {
-    if return_value != INVALID_HANDLE_VALUE {
-        Ok(return_value)
-    } else {
-        Err(io::Error::last_os_error())
-    }
-}
-
-/// Get the result of a call to WinAPI that returns a handle or `NULL`.
-#[inline]
-pub fn nonnull_handle_result(return_value: HANDLE) -> io::Result<HANDLE> {
-    if return_value.is_null() {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(return_value)
     }
 }

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -1,8 +1,8 @@
-use std::{io, ptr};
+use std::io;
 
-use winapi::um::synchapi::{CreateSemaphoreW, ReleaseSemaphore};
+use windows::Win32::System::Threading::{CreateSemaphoreW, ReleaseSemaphore};
 
-use crate::{nonnull_handle_result, result, Handle};
+use crate::Handle;
 
 /// A [Windows semaphore](https://docs.microsoft.com/en-us/windows/win32/sync/semaphore-objects).
 #[derive(Clone, Debug)]
@@ -14,10 +14,14 @@ impl Semaphore {
     /// This wraps
     /// [`CreateSemaphoreW`](https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createsemaphorew).
     pub fn new() -> io::Result<Self> {
-        let handle = nonnull_handle_result(unsafe {
-            CreateSemaphoreW(ptr::null_mut(), 0, 1, ptr::null_mut())
-        })?;
-
+        let handle = unsafe {
+            CreateSemaphoreW(
+                None,                  // no security attributes
+                0,                     // initial count
+                1,                     // maximum count
+                windows::core::w!(""), // unnamed semaphore
+            )
+        }?;
         let handle = unsafe { Handle::from_raw(handle) };
         Ok(Self(handle))
     }
@@ -27,7 +31,9 @@ impl Semaphore {
     /// This wraps
     /// [`ReleaseSemaphore`](https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-releasesemaphore).
     pub fn release(&self) -> io::Result<()> {
-        result(unsafe { ReleaseSemaphore(*self.0, 1, ptr::null_mut()) })
+        let previous_count = None;
+        unsafe { ReleaseSemaphore(*self.0, 1, previous_count) }?;
+        Ok(())
     }
 
     /// Access the underlying handle to the semaphore.

--- a/src/structs/coord.rs
+++ b/src/structs/coord.rs
@@ -2,7 +2,7 @@
 //! For example, in WinAPI we have `COORD` which looks and feels inconvenient.
 //! This module provides also some trait implementations who will make parsing and working with `COORD` easier.
 
-use winapi::um::wincon::COORD;
+use windows::Win32::System::Console::COORD;
 
 /// This is type represents the position of something on a certain 'x' and 'y'.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd)]
@@ -35,8 +35,8 @@ impl From<Coord> for COORD {
     }
 }
 
-impl Into<(u16, u16)> for Coord {
-    fn into(self) -> (u16, u16) {
-        (self.x as u16, self.y as u16)
+impl From<Coord> for (u16, u16) {
+    fn from(val: Coord) -> Self {
+        (val.x as u16, val.y as u16)
     }
 }

--- a/src/structs/input.rs
+++ b/src/structs/input.rs
@@ -9,8 +9,7 @@
 //! - `InputEventType`
 //! - `INPUT_RECORD`
 
-use winapi::shared::minwindef::DWORD;
-use winapi::um::wincon::{
+use windows::Win32::System::Console::{
     FOCUS_EVENT, FOCUS_EVENT_RECORD, FROM_LEFT_1ST_BUTTON_PRESSED, FROM_LEFT_2ND_BUTTON_PRESSED,
     FROM_LEFT_3RD_BUTTON_PRESSED, FROM_LEFT_4TH_BUTTON_PRESSED, INPUT_RECORD, KEY_EVENT,
     KEY_EVENT_RECORD, MENU_EVENT, MENU_EVENT_RECORD, MOUSE_EVENT, MOUSE_EVENT_RECORD,
@@ -18,6 +17,7 @@ use winapi::um::wincon::{
 };
 
 use super::Coord;
+
 use crate::ScreenBuffer;
 
 /// A [keyboard input event](https://docs.microsoft.com/en-us/windows/console/key-event-record-str).
@@ -51,11 +51,11 @@ impl KeyEventRecord {
     #[inline]
     fn from_winapi(record: &KEY_EVENT_RECORD) -> Self {
         KeyEventRecord {
-            key_down: record.bKeyDown != 0,
+            key_down: record.bKeyDown.as_bool(),
             repeat_count: record.wRepeatCount,
             virtual_key_code: record.wVirtualKeyCode,
             virtual_scan_code: record.wVirtualScanCode,
-            u_char: unsafe { *record.uChar.UnicodeChar() },
+            u_char: unsafe { record.uChar.UnicodeChar },
             control_key_state: ControlKeyState(record.dwControlKeyState),
         }
     }
@@ -121,9 +121,9 @@ pub struct ButtonState {
     state: i32,
 }
 
-impl From<DWORD> for ButtonState {
+impl From<u32> for ButtonState {
     #[inline]
-    fn from(event: DWORD) -> Self {
+    fn from(event: u32) -> Self {
         let state = event as i32;
         ButtonState { state }
     }
@@ -162,16 +162,6 @@ impl ButtonState {
     /// Returns whether there is a up scroll.
     pub fn scroll_up(&self) -> bool {
         self.state > 0
-    }
-
-    /// Returns whether there is a horizontal scroll to the right.
-    pub fn scroll_right(&self) -> bool {
-        self.state > 0
-    }
-
-    /// Returns whether there is a horizontal scroll to the left.
-    pub fn scroll_left(&self) -> bool {
-        self.state < 0
     }
 
     /// Returns the raw state.
@@ -228,8 +218,8 @@ pub enum EventFlags {
 }
 
 // TODO: Replace with TryFrom.
-impl From<DWORD> for EventFlags {
-    fn from(event: DWORD) -> Self {
+impl From<u32> for EventFlags {
+    fn from(event: u32) -> Self {
         match event {
             0x0000 => EventFlags::PressOrRelease,
             0x0002 => EventFlags::DoubleClick,
@@ -269,7 +259,7 @@ impl From<FOCUS_EVENT_RECORD> for FocusEventRecord {
     #[inline]
     fn from(record: FOCUS_EVENT_RECORD) -> Self {
         FocusEventRecord {
-            set_focus: record.bSetFocus != 0,
+            set_focus: record.bSetFocus.as_bool(),
         }
     }
 }
@@ -313,14 +303,14 @@ pub enum InputRecord {
 impl From<INPUT_RECORD> for InputRecord {
     #[inline]
     fn from(record: INPUT_RECORD) -> Self {
-        match record.EventType {
+        match record.EventType as u32 {
             KEY_EVENT => InputRecord::KeyEvent(KeyEventRecord::from_winapi(unsafe {
-                record.Event.KeyEvent()
+                &record.Event.KeyEvent
             })),
-            MOUSE_EVENT => InputRecord::MouseEvent(unsafe { *record.Event.MouseEvent() }.into()),
+            MOUSE_EVENT => InputRecord::MouseEvent(unsafe { record.Event.MouseEvent }.into()),
             WINDOW_BUFFER_SIZE_EVENT => InputRecord::WindowBufferSizeEvent({
                 let mut buffer =
-                    unsafe { WindowBufferSizeRecord::from(*record.Event.WindowBufferSizeEvent()) };
+                    unsafe { WindowBufferSizeRecord::from(record.Event.WindowBufferSizeEvent) };
                 let window = ScreenBuffer::current().unwrap().info().unwrap();
                 let screen_size = window.terminal_size();
 
@@ -329,8 +319,8 @@ impl From<INPUT_RECORD> for InputRecord {
 
                 buffer
             }),
-            FOCUS_EVENT => InputRecord::FocusEvent(unsafe { *record.Event.FocusEvent() }.into()),
-            MENU_EVENT => InputRecord::MenuEvent(unsafe { *record.Event.MenuEvent() }.into()),
+            FOCUS_EVENT => InputRecord::FocusEvent(unsafe { record.Event.FocusEvent }.into()),
+            MENU_EVENT => InputRecord::MenuEvent(unsafe { record.Event.MenuEvent }.into()),
             code => panic!("Unexpected INPUT_RECORD EventType: {}", code),
         }
     }

--- a/src/structs/input.rs
+++ b/src/structs/input.rs
@@ -164,6 +164,16 @@ impl ButtonState {
         self.state > 0
     }
 
+    /// Returns whether there is a horizontal scroll to the right.
+    pub fn scroll_right(&self) -> bool {
+        self.state > 0
+    }
+
+    /// Returns whether there is a horizontal scroll to the left.
+    pub fn scroll_left(&self) -> bool {
+        self.state < 0
+    }
+
     /// Returns the raw state.
     pub fn state(&self) -> i32 {
         self.state

--- a/src/structs/size.rs
+++ b/src/structs/size.rs
@@ -2,7 +2,7 @@
 //! For example, in WinAPI we have `COORD` to represent screen/buffer size but this is a little inconvenient.
 //! This module provides some trait implementations who will make parsing and working with `COORD` easier.
 
-use winapi::um::wincon::COORD;
+use windows::Win32::System::Console::COORD;
 
 /// This is type represents the size of something in width and height.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
@@ -24,8 +24,8 @@ impl From<COORD> for Size {
     }
 }
 
-impl Into<(u16, u16)> for Size {
-    fn into(self) -> (u16, u16) {
-        (self.width as u16, self.height as u16)
+impl From<Size> for (u16, u16) {
+    fn from(val: Size) -> Self {
+        (val.width as u16, val.height as u16)
     }
 }

--- a/src/structs/window_coords.rs
+++ b/src/structs/window_coords.rs
@@ -2,7 +2,7 @@
 //! For example, in WinAPI we have `SMALL_RECT` to represent a window size but this is a little inconvenient.
 //! This module provides some trait implementations who will make parsing and working with `SMALL_RECT` easier.
 
-use winapi::um::wincon::{CONSOLE_SCREEN_BUFFER_INFO, SMALL_RECT};
+use windows::Win32::System::Console::{CONSOLE_SCREEN_BUFFER_INFO, SMALL_RECT};
 
 /// This is a wrapper for the locations of a rectangle.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]


### PR DESCRIPTION
This replaces https://github.com/crossterm-rs/crossterm-winapi/pull/26
Using the windows crate instead of the windows-sys crate simplifies the
code and avoids having to maintain code that handles errors, and various
other simplifications provided by the higher level crate.

From the windows crate documentation:

> The windows-sys crate is a zero-overhead fallback for the most
> demanding situations and primarily where the absolute best compile
> time is essential. It only includes function declarations (externs),
> structs, and constants. No convenience helpers, traits, or wrappers
> are provided.
